### PR TITLE
Update Dependabot configuration for target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "dependency-updates" # Dependabot PRs go here instead of main
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
Configure Dependabot to target 'dependency-updates' branch and set commit message prefix.